### PR TITLE
Update dependencies listed in setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Adding Storybook into your project is a quick process:
     ```
 3. Install the Storybook `devDependencies`:<br>
     ```bash
-    npm i -D @babel/core @babel/preset-env @storybook/addon-a11y @storybook/addon-knobs @storybook/addon-viewport @storybook/html faker babel-loader css-loader node-sass sass-loader style-loader twig twig-loader webpack-cli
+    npm i -D @babel/core @babel/preset-env @storybook/addon-a11y @storybook/addon-knobs @storybook/addon-viewport @storybook/html faker babel-loader css-loader node-sass sass-loader style-loader twig twigjs-loader webpack-cli
     ```
 4. Add these script definitions into your `package.json`:
     ```js


### PR DESCRIPTION
This project now depends on twigjs-loader instead of twig-loader, but the instructions still say to install the twig-loader package. This commit fixes that.