### PR TITLE
babel-plugin-module-resolver Added to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Adding Storybook into your project is a quick process:
     ```
 3. Install the Storybook `devDependencies`:<br>
     ```bash
-    npm i -D @babel/core @babel/preset-env @storybook/addon-a11y @storybook/addon-knobs @storybook/addon-viewport @storybook/html faker babel-loader css-loader node-sass sass-loader style-loader twig twigjs-loader webpack-cli
+    npm i -D @babel/core @babel/preset-env @storybook/addon-a11y @storybook/addon-knobs @storybook/addon-viewport @storybook/html faker babel-loader css-loader node-sass sass-loader style-loader twig twigjs-loader babel-plugin-module-resolver webpack-cli
     ```
 4. Add these script definitions into your `package.json`:
     ```js


### PR DESCRIPTION
When [this commit](https://github.com/ben-rogerson/craft-storybook-starter/commit/6bacf7e9b59f22c2a6c04903ef10a0e53e100a18) came in `babel-plugin-module-resolver` was a new dependency which needed to get added to the readme.